### PR TITLE
Add Canvas AutoScale

### DIFF
--- a/src/js/game/properties.js
+++ b/src/js/game/properties.js
@@ -11,5 +11,6 @@ module.exports = {
     x: 1024,
     y: 768
   },
+  background: '#000',
   //analyticsId: 'UA-50892214-2'
 };

--- a/src/js/game/properties.js
+++ b/src/js/game/properties.js
@@ -12,5 +12,6 @@ module.exports = {
     y: 768
   },
   background: '#000',
+  autoScale: true,
   //analyticsId: 'UA-50892214-2'
 };

--- a/src/js/game/states/boot.js
+++ b/src/js/game/states/boot.js
@@ -1,4 +1,5 @@
 var Stats = require('../../lib/stats.min');
+var AutoScale = require('../../lib/autoscale');
 var properties = require('../properties');
 var boot = {};
 
@@ -6,6 +7,10 @@ boot.create = function () {
 
   if (properties.showStats) {
     addStats(this.game);
+  }
+
+  if (properties.autoScale) {
+    AutoScale();
   }
 
   this.game.sound.mute = properties.mute;

--- a/src/js/lib/autoscale.js
+++ b/src/js/lib/autoscale.js
@@ -1,0 +1,27 @@
+(function(){
+  var canvas;
+
+  function AutoScale() {
+    var game = document.getElementById( 'game' )
+    game.classList.add( 'autoscale' )
+
+    canvas = game.children[0]
+
+    window.addEventListener( 'resize', autoScaleCanvas )
+    autoScaleCanvas()
+  }
+
+  function autoScaleCanvas() {
+    var autoWidthClass = 'autowidth'
+    var wHeight = window.innerHeight
+    var cHeight = canvas.offsetHeight
+
+    if (cHeight >= wHeight) {
+      canvas.classList.remove( autoWidthClass )
+    } else {
+      canvas.classList.add( autoWidthClass )
+    }
+  }
+
+  module.exports = AutoScale
+})()

--- a/src/style/page.styl
+++ b/src/style/page.styl
@@ -1,2 +1,21 @@
 body
   margin 0
+
+#game.autoscale
+  position absolute
+  width 100%
+  height 100%
+
+  canvas
+    margin auto
+    width auto !important
+    height: 100% !important
+
+    &.autowidth
+      width 100% !important
+      height: auto !important
+
+      // vertically centre
+      position absolute
+      top 50%
+      transform translateY(-50%)

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -13,6 +13,10 @@ html
 
     include analytics.jade
 
+    style(type='text/css').
+      body {
+        background: #{properties.background};
+      }
   body
     #game
 

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -11,13 +11,13 @@ html
 
     title=properties.title
 
-    script(src="js/phaser.js")
-    script(src="js/app.min.js")
-
     include analytics.jade
 
   body
     #game
+
+    script(src="js/phaser.js")
+    script(src="js/app.min.js")
 
     if (!productionBuild)
       script.


### PR DESCRIPTION
Adds an option to centre and scale the canvas to the browser window, no matter what size or proportion.

Set the options in the [properties.js](https://github.com/PixelTom/phaser-es6-boilerplate/blob/master/src/js/game/properties.js) file:

```
  background: '#000', // change the html background colour
  autoScale: true, // enable / disable AutoScale
```