### PR TITLE
Add scaleMode fix to autoscaling canvas

### DIFF
--- a/src/js/game/states/boot.js
+++ b/src/js/game/states/boot.js
@@ -10,6 +10,7 @@ boot.create = function () {
   }
 
   if (properties.autoScale) {
+    this.game.scale.scaleMode = Phaser.ScaleManager.SHOW_ALL;
     AutoScale();
   }
 


### PR DESCRIPTION
This is to ensure the click and drag coordinates are still correct relative to the game objects.

**Test case:**
Add these lines to [game.js](https://github.com/PixelTom/phaser-es6-boilerplate/blob/feature/autoscale-canvas/src/js/game/states/game.js#L5):

```
  logo.inputEnabled = true;
  logo.events.onInputDown.add( () => console.log('target correct!') );
```

Load up the game and click on the logo.
The console should show "target correct!" no matter what scale the page is.